### PR TITLE
fix (authentication):  Unauthenticated user receives error navigating to pages.

### DIFF
--- a/src/Nuages.Identity.Services/NuagesIdentityConfigExtensions.cs
+++ b/src/Nuages.Identity.Services/NuagesIdentityConfigExtensions.cs
@@ -87,6 +87,7 @@ public static class NuagesIdentityConfigExtensions
                 options.DefaultScheme = CookieAuthenticationDefaults.AuthenticationScheme;
                 options.DefaultChallengeScheme = CookieAuthenticationDefaults.AuthenticationScheme;
             })
+            .AddCookie(CookieAuthenticationDefaults.AuthenticationScheme)
             .AddCookie(NuagesIdentityConstants.EmailNotVerifiedScheme)
             .AddCookie(NuagesIdentityConstants.ResetPasswordScheme)
             .AddCookie(NuagesIdentityConstants.PasswordExpiredScheme)


### PR DESCRIPTION
Fix an issue where an unauthenticated user who navigates to controller page will receive an error `InvalidOperationException: No authenticationScheme was specified, and there was no DefaultChallengeScheme found`

resolves #2 

Please review, security is not my strong point. 